### PR TITLE
Removed a trailing comma

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -396,7 +396,7 @@
     /fish$/, // "fish", "blowfish", "angelfish"
     /sheep$/,
     /measles$/,
-    /[^aeiou]ese$/, // "chinese", "japanese"
+    /[^aeiou]ese$/ // "chinese", "japanese"
   ].forEach(pluralize.addUncountableRule);
 
   return pluralize;


### PR DESCRIPTION
In IE8, (once you've shimmed stuff like `.forEach()`), this causes an extra word `undefined` to be added to the uncountable rules. Removing the trailing comma fixes this.

I'm guessing IE8 support is the least of your concerns but as this seems like a trivial change it'd be great if you would consider merging it.
