### PR TITLE
failing test for case issue

### DIFF
--- a/test.js
+++ b/test.js
@@ -645,5 +645,12 @@ describe('pluralize', function () {
 
       expect(pluralize.singular('mornings')).to.equal('suck');
     });
+
+    it('should not modify letter cases', function () {
+      pluralize.addIrregularRule('UPPERCASE', 'UPPERCASEs');
+
+      expect(pluralize.plural('UPPERCASE')).to.equal('UPPERCASEs');
+    });
+
   });
 });


### PR DESCRIPTION
I think the library should not modify the letter cases specially when we add irregular rules. It might make some unexpected results. 