### PR TITLE
Add semicolon to end of file

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -428,4 +428,4 @@
   ].forEach(pluralize.addUncountableRule)
 
   return pluralize
-})
+});


### PR DESCRIPTION
Without a tailing semicolon, issues arise when combining this with other JavaScript libraries.