### PR TITLE
Add has => have rule

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -249,6 +249,7 @@
     ['themself', 'themselves'],
     ['is', 'are'],
     ['was', 'were'],
+    ['has', 'have'],
     ['this', 'these'],
     ['that', 'those'],
     // Words ending in with a consonant and `o`.


### PR DESCRIPTION
I saw you mentioned it's mostly about nouns, but anyway. Since `is` and `was` already there.