### PR TITLE
Fix tennis

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -438,6 +438,7 @@
     'species',
     'staff',
     'swine',
+    'tennis',
     'trout',
     'traffic',
     'transporation',

--- a/test.js
+++ b/test.js
@@ -21,6 +21,7 @@ var BASIC_TESTS = [
   ['reindeer', 'reindeer'],
   ['starfish', 'starfish'],
   ['smallpox', 'smallpox'],
+  ['tennis', 'tennis'],
   ['chickenpox', 'chickenpox'],
   ['shambles', 'shambles'],
   ['garbage', 'garbage'],


### PR DESCRIPTION
This pull request will fix issue #56, which returns `tenni` while `pluralize.singular('tennis')`.

Since Tennis is usually uncountable, I added the word to uncountables array.

Here is reference for word `tennis`

|https://en.wiktionary.org/wiki/tennis|
|:---:|
|<img width="410" alt="screen shot 2017-05-16 at 16 55 33" src="https://cloud.githubusercontent.com/assets/9393495/26095659/58255b1e-3a59-11e7-9e6d-2fdaf55e4259.png">|


