### PR TITLE
Fix bower deprecations / stale version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,7 @@
 {
   "name": "pluralize",
-  "version": "4.0.0",
   "description": "Pluralize and singularize any word",
   "main": "pluralize.js",
-  "repository": "blakeembrey/pluralize",
   "keywords": [
     "plural",
     "plurals",
@@ -12,11 +10,17 @@
     "singularize"
   ],
   "license": "MIT",
-  "scripts": [
-    "pluralize.js"
-  ],
   "homepage": "https://github.com/blakeembrey/pluralize",
   "authors": [
     "Blake Embrey <hello@blakeembrey.com>"
+  ],
+  "moduleType": [
+    "globals",
+    "amd",
+    "node"
+  ],
+  "ignore": [
+    "/.*",
+    "test.js"
   ]
 }


### PR DESCRIPTION
* The filename "components.json" is deprecated and "bower.json" should be used to avoid warnings.
* The "version" attribute is deprecated (and it was also outdated), so let's just remove it.
Bower does infer the version number from the git release tag automatically, so this removes a common maintenance headache.
* List compatible module types of main script.
* Drop invalid and redundant "repository" key (should be an object in current spec).
* Drop "scripts", it is specified by "main".
* Don't include hidden files and test.js in bower packages.