### PR TITLE
add support for ‘emphases’ => ‘emphasis’

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -373,7 +373,7 @@
     [/(x|ch|ss|sh|zz|tto|go|cho|alias|[^aou]us|tlas|gas|(?:her|at|gr)o|ris)(?:es)?$/i, '$1'],
     [/(e[mn]u)s?$/i, '$1'],
     [/(movie|twelve)s$/i, '$1'],
-    [/(cris|test|diagnos)(?:is|es)$/i, '$1is'],
+    [/(cris|test|emphas)(?:is|es)$/i, '$1is'],
     [/(alumn|syllab|octop|vir|radi|nucle|fung|cact|stimul|termin|bacill|foc|uter|loc|strat)(?:us|i)$/i, '$1us'],
     [/(agend|addend|millenni|dat|extrem|bacteri|desiderat|strat|candelabr|errat|ov|symposi|curricul|quor)a$/i, '$1um'],
     [/(apheli|hyperbat|periheli|asyndet|noumen|phenomen|criteri|organ|prolegomen|hedr|automat)a$/i, '$1on'],

--- a/test.js
+++ b/test.js
@@ -578,6 +578,7 @@ var BASIC_TESTS = [
   ['company', 'companies'],
   ['ceremony', 'ceremonies'],
   ['carnivore', 'carnivores'],
+  ['emphasis', 'emphases'],
   // Prototype inheritance.
   ['constructor', 'constructors'],
   // Non-standard case.


### PR DESCRIPTION
also, ‘diagnoses’ => ‘diagnosis’ was covered twice, I think.