### PR TITLE
Makes words with apostrophes uncountable

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -483,7 +483,8 @@
     /measles$/i,
     /o[iu]s$/i, // "carnivorous"
     /pox$/i, // "chickpox", "smallpox"
-    /sheep$/i
+    /sheep$/i,
+    /'/i
   ].forEach(pluralize.addUncountableRule);
 
   return pluralize;

--- a/test.js
+++ b/test.js
@@ -616,7 +616,8 @@ var SINGULAR_TESTS = [
   ['ghetto', 'ghettoes'],
   ['nucleus', 'nucleuses'],
   ['bureau', 'bureaux'],
-  ['seraph', 'seraphs']
+  ['seraph', 'seraphs'],
+  ["it's", "it's"]
 ];
 
 /**


### PR DESCRIPTION
To address #73.

I'm using the library for general-purpose text analysis where I don't care about the difference between singular and plural forms, so I singularize everything. This library is a great way to do it, but it doesn't currently handle possessives.