### PR TITLE
'police' is not countable (fix pluralize.singular('police') //=> "polouse"!)

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -451,6 +451,7 @@
     'pike',
     'plankton',
     'pliers',
+    'police',
     'pollution',
     'premises',
     'rain',


### PR DESCRIPTION
as entertaining as `pluralize.singular('police') //=> "polouse"` is...