### PR TITLE
Add analytics to the list of words with no plurals

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -397,6 +397,7 @@
     'aid',
     'alcohol',
     'ammo',
+    'analytics',
     'anime',
     'athletics',
     'audio',


### PR DESCRIPTION
According to the oxford dictionary `analytics` is both singular and plural:
* https://en.oxforddictionaries.com/definition/analytics