### PR TITLE
add test for enterprise -> enterprises

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -306,6 +306,7 @@
     ['yes', 'yeses'],
     ['foot', 'feet'],
     ['eave', 'eaves'],
+    ['enterprise', 'enterprises'],
     ['goose', 'geese'],
     ['tooth', 'teeth'],
     ['quiz', 'quizzes'],

--- a/test.js
+++ b/test.js
@@ -562,6 +562,7 @@ var BASIC_TESTS = [
   ['progressive', 'progressives'],
   ['laxative', 'laxatives'],
   ['incentive', 'incentives'],
+  ['enterprise', 'enterprises'],
   ['relative', 'relatives'],
   ['positive', 'positives'],
   ['perspective', 'perspectives'],


### PR DESCRIPTION
Currently `enterprises` as plural, is converted to singular as `enterpris` instead of `enterprise`.

Let's fix it!