### PR TITLE
Add "hardware" as a singular word with no plural

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -431,6 +431,7 @@
     'gallows',
     'garbage',
     'graffiti',
+    'hardware',
     'headquarters',
     'health',
     'herpes',

--- a/test.js
+++ b/test.js
@@ -35,6 +35,7 @@ var BASIC_TESTS = [
   ['carnivorous', 'carnivorous'],
   ['only', 'only'],
   ['aircraft', 'aircraft'],
+  ['hardware', 'hardware'],
   // Latin.
   ['veniam', 'veniam'],
   // Pluralization.


### PR DESCRIPTION
Plural of hardware is hardware, not hardwares.