### PR TITLE
Add possessive functionality, handling plural/singular cases.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,6 +81,12 @@ pluralize.plural('paper') //=> "paper"
 // Example of asking whether a word looks singular or plural:
 pluralize.isPlural('test') //=> false
 pluralize.isSingular('test') //=> true
+
+// Example of making a word possessive, handling plural cases:
+pluralize.posessive('Bob') // => "Bob's"
+pluralize.posessive('sheep') // => "sheep's"
+pluralize.posessive('dress') // => "dress's"
+pluralize.posessive('dresses') // => "dresses'"
 ```
 
 ## License

--- a/pluralize.js
+++ b/pluralize.js
@@ -180,6 +180,15 @@
   }
 
   /**
+   * Make a word posessive handling plurals properly.
+   *
+   * @type {Function}
+   */
+  pluralize.possessive = function (word) {
+    return word + (pluralize.isPlural(word) && word.endsWith('s') ? "'" : "'s");
+  };
+
+  /**
    * Pluralize a word.
    *
    * @type {Function}

--- a/pluralize.js
+++ b/pluralize.js
@@ -185,7 +185,13 @@
    * @type {Function}
    */
   pluralize.possessive = function (word) {
-    return word + (pluralize.isPlural(word) && word.endsWith('s') ? "'" : "'s");
+    var possessiveWord = word + "'s";
+
+    if (word.endsWith('s') && pluralize.isPlural(word)) {
+      possessiveWord = possessiveWord.slice(0, -1); // Drop the "s"
+    }
+
+    return possessiveWord;
   };
 
   /**

--- a/test.js
+++ b/test.js
@@ -660,6 +660,16 @@ var PLURAL_TESTS = [
   ['passerby', 'passersby']
 ];
 
+var POSESSIVE_TESTS = [
+  ['Bob', "Bob's"],
+  ['dress', "dress's"],
+  ['dresses', "dresses'"],
+  ['whisky', "whisky's"],
+  ['whiskies', "whiskies'"],
+  ['sheep', "sheep's"],
+  ['christmas', "christmas's"]
+];
+
 /**
  * Test suite.
  */
@@ -693,6 +703,14 @@ describe('pluralize', function () {
       BASIC_TESTS.concat(SINGULAR_TESTS).forEach(function (test) {
         it('isSingular(' + test[0] + ')', function () {
           expect(pluralize.isSingular(test[0])).to.equal(true);
+        });
+      });
+    });
+
+    describe('possessive', function () {
+      POSESSIVE_TESTS.forEach(function (test) {
+        it(test[0] + ' -> ' + test[1], function () {
+          expect(pluralize.possessive(test[0])).to.equal(test[1]);
         });
       });
     });


### PR DESCRIPTION
Had a conversation with a co-worker about the utility of this library and how we'd need only add a bit of our own functionality to achieve proper handling of possessive punctuation for plural and singular words. Then I figured, why not just contribute straight to the library?

Here's the result.