### PR TITLE
Add `graffito -> graffiti` irregular rule

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -289,6 +289,7 @@
     // Words ending in with a consonant and `o`.
     ['echo', 'echoes'],
     ['dingo', 'dingoes'],
+    ['graffito', 'graffiti'],
     ['volcano', 'volcanoes'],
     ['tornado', 'tornadoes'],
     ['torpedo', 'torpedoes'],
@@ -433,7 +434,6 @@
     'fun',
     'gallows',
     'garbage',
-    'graffiti',
     'hardware',
     'headquarters',
     'health',


### PR DESCRIPTION
This PR adds the singular form of the word **graffiti**.

Currently, graffiti is defined in the code as the irregular singular form of the word.

https://github.com/blakeembrey/pluralize/blob/abb399111aedd1d62dd418d7e0217d85f5bf22c9/pluralize.js#L436

The word graffiti _is_ the plural form of the word, not the singular and only form as defined in the code.

The singular version of graffiti is **graffito**.

It's an Italian word; that's why it has a weird structure. I should also note that while this is the correct usage of the word, graffito isn't often used in English as many people aren't aware of it.