### PR TITLE
Create addRestoreCaseException function 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,6 +81,11 @@ pluralize.plural('paper') //=> "paper"
 // Example of asking whether a word looks singular or plural:
 pluralize.isPlural('test') //=> false
 pluralize.isSingular('test') //=> true
+
+// Example of adding a token exception whose case should not be restored:
+pluralize.plural('promo ID') //=> 'promo IDS'
+pluralize.addRestoreCaseException('IDs')
+pluralize.plural('promo ID') //=> 'promo IDs'
 ```
 
 ## License

--- a/pluralize.js
+++ b/pluralize.js
@@ -22,6 +22,7 @@
   var uncountables = {};
   var irregularPlurals = {};
   var irregularSingles = {};
+  var restoreCaseExceptions = [];
 
   /**
    * Sanitize a pluralization rule to a usable regular expression.
@@ -31,7 +32,7 @@
    */
   function sanitizeRule (rule) {
     if (typeof rule === 'string') {
-      return new RegExp('^' + rule + '$', 'i');
+      return new RegExp(rule + '$', 'i');
     }
 
     return rule;
@@ -46,6 +47,9 @@
    * @return {Function}
    */
   function restoreCase (word, token) {
+    // Do not restore the case of specified tokens
+    if (restoreCaseExceptions.indexOf(token) !== -1) return token;
+
     // Tokens are an exact match.
     if (word === token) return token;
 
@@ -115,7 +119,6 @@
     // Iterate over the sanitization rules and use the first one to match.
     while (len--) {
       var rule = rules[len];
-
       if (rule[0].test(word)) return replace(word, rule);
     }
 
@@ -223,6 +226,16 @@
    */
   pluralize.addPluralRule = function (rule, replacement) {
     pluralRules.push([sanitizeRule(rule), replacement]);
+  };
+
+  /**
+   * Add an exception to restoreCase.
+   *
+   * @param {string} exception
+   */
+
+  pluralize.addRestoreCaseException = function (exception) {
+    restoreCaseExceptions.push(exception);
   };
 
   /**

--- a/test.js
+++ b/test.js
@@ -832,5 +832,12 @@ describe('pluralize', function () {
 
       expect(pluralize.singular('mornings')).to.equal('suck');
     });
+
+    it('will skip restoring case on specified token exceptions', function () {
+      expect(pluralize.plural('promo ID')).to.equal('promo IDS');
+      pluralize.addRestoreCaseException('IDs');
+      pluralize.addPluralRule('ID', 'IDs');
+      expect(pluralize.plural('promo ID')).to.equal('promo IDs');
+    });
   });
 });


### PR DESCRIPTION
I use the `pluralize` library frequently and wanted to be able to pluralize `promo ID` => `promo IDs`

I can add a plural rule but the `restoreCase` function restores the case so that the result is `promo IDS`

I created a function `addRestoreCaseException` which takes a token argument and pushes it to an array of `restoreCaseExceptions`

If a `token` is found in the array of `restoreCaseExceptions` then the token's case is not restored.

I also added a test and updated the readme. 