### PR TITLE
Add methods for exposing internal state

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -266,6 +266,41 @@
   };
 
   /**
+   * Get all known plural rules.
+   */
+  pluralize.getPluralRules = function () {
+    return pluralRules;
+  };
+
+  /**
+   * Get all known singular rules.
+   */
+  pluralize.getSingularRules = function () {
+    return singularRules;
+  };
+
+  /**
+   * Get all known uncountable words.
+   */
+  pluralize.getUncountables = function () {
+    return uncountables;
+  };
+
+  /**
+   * Get all known irregular plural words.
+   */
+  pluralize.getIrregularPlurals = function () {
+    return irregularPlurals;
+  };
+
+  /**
+   * Get all known irregular single words.
+   */
+  pluralize.getIrregularSingles = function () {
+    return irregularSingles;
+  };
+
+  /**
    * Irregular rules.
    */
   [

--- a/test.js
+++ b/test.js
@@ -833,4 +833,35 @@ describe('pluralize', function () {
       expect(pluralize.singular('mornings')).to.equal('suck');
     });
   });
+
+  describe('getting existing rules', function () {
+    it('should allow access to plural rules', function () {
+      var rules = pluralize.getPluralRules();
+      expect(rules).to.be.an('array');
+    });
+
+    it('should allow access to singular rules', function () {
+      var rules = pluralize.getSingularRules();
+      expect(rules).to.be.an('array');
+    });
+  });
+
+  describe('getting uncountable words', function () {
+    it('should allow access to uncountable words', function () {
+      var uncountable = pluralize.getUncountables();
+      expect(uncountable).to.be.ok.and.an('object');
+    });
+  });
+
+  describe('getting irregular words', function () {
+    it('should allow access to irregular plural words', function () {
+      var irregular = pluralize.getIrregularPlurals();
+      expect(irregular).to.be.ok.and.an('object');
+    });
+
+    it('should allow access to irregular singular words', function () {
+      var irregular = pluralize.getIrregularSingles();
+      expect(irregular).to.be.ok.and.an('object');
+    });
+  });
 });


### PR DESCRIPTION
Hi @blakeembrey,

I hope you are doing well. This pull request introduces 4 methods on the `pluralize` function that expose the internal state of this module. The intended purpose of this methods could be for introspection on how this module may handle a word given to it. Consider the word `audio` as an example. The plural form of this word is also `audio`. However, there are accepted uses of the alternative plural form of this word: `audios`. While this may not be heard or spoken often for English speakers, it could become common in computer speak, like resource naming in APIs. I hope this makes sense

