### PR TITLE
"viruses" instead of "viri"

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -341,7 +341,7 @@
     [/(alias|[^aou]us|t[lm]as|gas|ris)$/i, '$1es'],
     [/(e[mn]u)s?$/i, '$1s'],
     [/([^l]ias|[aeiou]las|[ejzr]as|[iu]am)$/i, '$1'],
-    [/(alumn|syllab|vir|radi|nucle|fung|cact|stimul|termin|bacill|foc|uter|loc|strat)(?:us|i)$/i, '$1i'],
+    [/(alumn|syllab|radi|nucle|fung|cact|stimul|termin|bacill|foc|uter|loc|strat)(?:us|i)$/i, '$1i'],
     [/(alumn|alg|vertebr)(?:a|ae)$/i, '$1ae'],
     [/(seraph|cherub)(?:im)?$/i, '$1im'],
     [/(her|at|gr)o$/i, '$1oes'],

--- a/test.js
+++ b/test.js
@@ -194,7 +194,7 @@ var BASIC_TESTS = [
   ['die', 'dice'],
   ['penny', 'pennies'],
   ['campus', 'campuses'],
-  ['virus', 'viri'],
+  ['virus', 'viruses'],
   ['iris', 'irises'],
   ['bureau', 'bureaus'],
   ['kiwi', 'kiwis'],


### PR DESCRIPTION
"viri" is an old flame war/joke where "viruses" is correct and "viri" is a fake word used by some computer people for fun

https://en.wikipedia.org/wiki/Plural_form_of_words_ending_in_-us#Virus

https://books.google.com/ngrams/graph?content=viri%2Cviruses&year_start=1800&year_end=2022&corpus=en&smoothing=3&case_insensitive=true

Other special cases that could be also removed are "cactus/cacti", "syllabus/syllabi" and "terminus/termini".